### PR TITLE
feat(vscode): Retrieve imports from fluence CLI [LNG-252]

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { ExtensionContext, workspace } from 'vscode';
+import type { ExtensionContext } from 'vscode';
 
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 
@@ -30,10 +30,6 @@ export function activate(context: ExtensionContext) {
     const clientOptions: LanguageClientOptions = {
         // Register the server for aqua source files
         documentSelector: [{ pattern: '**/*.aqua' }],
-        synchronize: {
-            // Notify the server about file changes to '.clientrc files contained in the workspace
-            fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
-        },
     };
 
     // Create the language client and start the client.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Do not look for extra imports"
+                },
+                "aquaSettings.fluencePath": {
+                    "scope": "resource",
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Path to fluence CLI executable"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -62,19 +62,17 @@
             "type": "object",
             "title": "Aqua",
             "properties": {
-                "aquaSettings": {
-                    "imports": {
-                        "scope": "resource",
-                        "type": "array",
-                        "default": [],
-                        "description": "Adds imports for aqua file or project"
-                    },
-                    "enableLegacyAutoImportSearch": {
-                        "scope": "resource",
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Do not look for extra imports"
-                    }
+                "aquaSettings.imports": {
+                    "scope": "resource",
+                    "type": "array",
+                    "default": [],
+                    "description": "Adds imports for aqua file or project"
+                },
+                "aquaSettings.enableLegacyAutoImportSearch": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Do not look for extra imports"
                 }
             }
         }

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,0 +1,45 @@
+import { exec } from 'child_process';
+
+export class FluenceCli {
+    readonly cliPath: string;
+
+    /**
+     * @param cliPath Path to `fluence` executable.
+     * Defaults to `fluence` (i.e. it should be in PATH).
+     */
+    constructor(cliPath?: string) {
+        this.cliPath = cliPath || 'fluence';
+    }
+
+    /**
+     * Returns output of `fluence aqua imports`
+     */
+    async imports(): Promise<string[]> {
+        const result = await this.runJson(['aqua', 'imports']);
+        if (Array.isArray(result) && result.every((i) => typeof i === 'string')) {
+            return result;
+        } else {
+            throw new Error(`Invalid result: ${JSON.stringify(result)}`);
+        }
+    }
+
+    /**
+     * Runs `fluence` with given arguments and returns its stdout as JSON.
+     */
+    private async runJson(args: string[]): Promise<JSON> {
+        const cmd = `${this.cliPath} ${args.join(' ')}`;
+        return new Promise((resolve, reject) => {
+            exec(cmd, (err, stdout, _) => {
+                if (err) {
+                    reject(err);
+                } else
+                    try {
+                        const result = JSON.parse(stdout);
+                        resolve(result);
+                    } catch (e) {
+                        reject(e);
+                    }
+            });
+        });
+    }
+}

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -29,7 +29,7 @@ export class SettingsManager {
     private globalSettings: Settings = this.defaultSettings;
     private documentSettings: Map<string, Settings> = new Map();
 
-    private additionalImports: string[] | undefined;
+    private additionalImports: string[] = [];
     private additionalImportsLastUpdated = 0;
     private additionalImportsUpdateRequested = true;
 

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -1,0 +1,111 @@
+import type { Configuration } from 'vscode-languageserver/lib/common/configuration';
+
+import type { FluenceCli } from './cli';
+
+export interface Settings {
+    imports: string[];
+    enableLegacyAutoImportSearch: boolean;
+}
+
+function addImports(settings: Settings, imports?: string[]): Settings {
+    if (!imports || imports.length === 0) {
+        return settings;
+    }
+
+    return {
+        ...settings,
+        imports: [...settings.imports, ...imports],
+    };
+}
+
+/**
+ * Compilation settings manager for documents
+ */
+export class SettingsManager {
+    private readonly defaultSettings: Settings = {
+        imports: [],
+        enableLegacyAutoImportSearch: false,
+    };
+    private globalSettings: Settings = this.defaultSettings;
+    private documentSettings: Map<string, Settings> = new Map();
+
+    private additionalImports: string[] | undefined;
+    private additionalImportsLastUpdated = 0;
+    private additionalImportsUpdateRequested = true;
+
+    private readonly cli: FluenceCli;
+    private readonly configuration: Configuration | undefined;
+
+    constructor(cli: FluenceCli, configuration?: Configuration, defaultSettings?: Settings) {
+        this.cli = cli;
+        this.configuration = configuration;
+        if (defaultSettings) {
+            this.defaultSettings = defaultSettings;
+        }
+    }
+
+    /**
+     * Get settings for document or global settings if document settings are not available
+     *
+     * @param uri Document uri
+     * @returns Settings for the document
+     */
+    async getDocumentSettings(uri: string): Promise<Settings> {
+        await this.tryUpdateDocumentSettings(uri);
+
+        const settings = this.documentSettings.get(uri) || this.globalSettings;
+
+        await this.tryUpdateAdditionalImports();
+
+        return addImports(settings, this.additionalImports);
+    }
+
+    /**
+     * Remove document settings from cache
+     *
+     * @param uri Document uri
+     */
+    removeDocumentSettings(uri: string): void {
+        this.documentSettings.delete(uri);
+    }
+
+    /**
+     * Set flag to request additional imports update.
+     * This flag will be reset after first successful update.
+     * NOTE: Imports are updated no more than once in 5 seconds.
+     */
+    requestImportsUpdate() {
+        this.additionalImportsUpdateRequested = true;
+    }
+
+    private async tryUpdateDocumentSettings(uri: string): Promise<void> {
+        if (this.configuration && !this.documentSettings.has(uri)) {
+            // TODO: Handle errors
+            const settings = await this.configuration.getConfiguration({
+                scopeUri: uri,
+                section: 'aquaSettings',
+            });
+            if (settings) {
+                this.documentSettings.set(uri, settings);
+            }
+        }
+    }
+
+    private async tryUpdateAdditionalImports(): Promise<void> {
+        const now = Date.now();
+        // Update additional imports not more often than once in 5 seconds
+        // and only if there is a request to update
+        if (now - this.additionalImportsLastUpdated < 5000 || !this.additionalImportsUpdateRequested) {
+            return;
+        }
+
+        try {
+            this.additionalImports = await this.cli.imports();
+            this.additionalImportsLastUpdated = now;
+            this.additionalImportsUpdateRequested = false;
+        } catch (e) {
+            // TODO: Handle this more gracefully
+            console.log('Failed to update additional imports', e);
+        }
+    }
+}

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -8,13 +8,9 @@ export interface Settings {
 }
 
 function addImports(settings: Settings, imports?: string[]): Settings {
-    if (!imports || imports.length === 0) {
-        return settings;
-    }
-
     return {
         ...settings,
-        imports: [...settings.imports, ...imports],
+        imports: [...settings.imports, ...(imports ?? [])],
     };
 }
 

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -7,7 +7,7 @@ import type { WorkspaceFolder } from 'vscode-languageserver-protocol';
 
 import { AquaLSP, ErrorInfo, TokenLink, WarningInfo } from '@fluencelabs/aqua-language-server-api/aqua-lsp-api';
 
-import type { Settings } from './server';
+import type { Settings } from './settings';
 
 function findNearestNodeModules(fileLocation: string, projectLocation: string): string | undefined {
     const relative = Path.relative(projectLocation, fileLocation);


### PR DESCRIPTION
* Fix settings: they are now displayed in VS Code UI
* Add Fluence CLI call to retrieve imports
* CLI is called no more than once in 5 seconds and only if it might be needed
* User can specify path to custom Fluence CLI