### PR TITLE
Catch error from `updateImports`

### DIFF
--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -127,8 +127,13 @@ export class SettingsManager {
 
         if (info.isImportsUpdateNeeded(this.cliCallDelay)) {
             const path = URI.parse(uri).fsPath;
-            const imports = await this.cli.imports(path);
-            info.updateImports(imports);
+            try {
+                const imports = await this.cli.imports(path);
+                info.updateImports(imports);
+            } catch (e) {
+                // try-catch is needed, because server will crash if there will be no Fluence CLI installed
+                console.error('Cannot update imports: ', e);
+            }
         }
 
         this.documents.set(uri, info);


### PR DESCRIPTION
If there is no fluence CLI, it can cause language server shutdown