### PR TITLE
fix(server): Decode URI before passing path to compiler

### DIFF
--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -48,9 +48,10 @@ export async function compileAqua(
     textDocument: TextDocument,
 ): Promise<[Diagnostic[], TokenLink[], TokenInfo[]]> {
     const uri = textDocument.uri.replace('file://', '');
+    const path = decodeURIComponent(uri);
 
     // compile aqua and get result
-    const result = await AquaLSP.compile(uri, settings.imports);
+    const result = await AquaLSP.compile(path, settings.imports);
 
     const diagnostics: Diagnostic[] = [];
     const links: TokenLink[] = [];


### PR DESCRIPTION
VS Code encodes URI. It means that, e.g. `@` is replaced with `%40`. It makes path passed to compiler incorrect, as compiler does not expect an encoded URI.