### PR TITLE
fix(vscode): Use path in locations to search definitions

### DIFF
--- a/server/src/info.ts
+++ b/server/src/info.ts
@@ -11,8 +11,10 @@ import { locInLoc, posInToken } from './utils';
 export class DocumentInfo {
     private links: TokenLink[];
     private tokens: TokenInfo[];
+    private path: string;
 
-    constructor(links: TokenLink[], tokens: TokenInfo[]) {
+    constructor(path: string, links: TokenLink[], tokens: TokenInfo[]) {
+        this.path = path;
         this.links = links;
         this.tokens = tokens;
     }
@@ -23,7 +25,7 @@ export class DocumentInfo {
      * @returns token info if found
      */
     infoAt(pos: Position): TokenInfo | undefined {
-        const info = this.tokens.find((token) => posInToken(pos, token.location));
+        const info = this.tokens.find((token) => posInToken(this.path, pos, token.location));
         if (info) {
             return info;
         }
@@ -44,7 +46,7 @@ export class DocumentInfo {
      * @returns Definition location if found
      */
     defAt(pos: Position): TokenLocation | undefined {
-        return this.links.find((link) => posInToken(pos, link.current))?.definition;
+        return this.links.find((link) => posInToken(this.path, pos, link.current))?.definition;
     }
 }
 

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -7,14 +7,16 @@ import type { TokenLocation } from '@fluencelabs/aqua-language-server-api/aqua-l
 
 /**
  * Check if position is inside token
+ * @param path path to file with token
  * @param position position to check
  * @param token token to check
  * @returns true if position is inside token
  * @note this ignores token's file name
  *       as position does not contain such info
  */
-export function posInToken(position: Position, token: TokenLocation): boolean {
+export function posInToken(path: string, position: Position, token: TokenLocation): boolean {
     return (
+        token.name == path &&
         token.startLine <= position.line &&
         token.startCol <= position.character &&
         token.endLine >= position.line &&
@@ -30,6 +32,7 @@ export function posInToken(position: Position, token: TokenLocation): boolean {
  */
 export function locInLoc(lhs: TokenLocation, rhs: TokenLocation): boolean {
     return (
+        lhs.name == rhs.name &&
         rhs.startLine <= lhs.startLine &&
         rhs.startCol <= lhs.startCol &&
         rhs.endLine >= lhs.endLine &&

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -84,7 +84,7 @@ export async function compileAqua(
     }
 
     const locations = result.locations.concat(links);
-    const info = new DocumentInfo(locations, result.tokens);
+    const info = new DocumentInfo(path, locations, result.tokens);
 
     return [diagnostics, info];
 }


### PR DESCRIPTION
In one document there can be tokens from multiple files. Compare paths in locations to prevent collisions.